### PR TITLE
Heroku build failed during CoffeeScript compile.

### DIFF
--- a/config/application.coffee
+++ b/config/application.coffee
@@ -11,9 +11,6 @@ module.exports = lineman.config.extend "application",
       description: "End-user documentation for Exercism.io"
       url: "<%= pkg.homepage %>"
       email: "kytrinyx@exercism.io"
-      paths:
-        archive: null
-        rss: null
       layouts:
         post: null
         archive: null


### PR DESCRIPTION
Error from heroku:

```
/tmp/build_ea0cbbef-9289-49f0-9b7a-dec1e6374440/node_modules/lineman/node_modules/grunt/node_modules/coffee-script/lib/coffee-script/coffee-script.js:51
      throw err;
            ^
SyntaxError: In /tmp/build_ea0cbbef-9289-49f0-9b7a-dec1e6374440/config/application.coffee, multiple object literal properties named "paths"
    at SyntaxError (<anonymous>)
    at Obj.exports.Obj.Obj.compileNode (/tmp/build_ea0cbbef-9289-49f0-9b7a-dec1e6374440/node_modules/lineman/node_modules/grunt/node_modules/coffee-script/lib/coffee-script/nodes.js:1187:19)
    at Obj.exports.Base.Base.compile (/tmp/build_ea0cbbef-9289-49f0-9b7a-dec1e6374440/node_modules/lineman/node_modules/grunt/node_modules/coffee-script/lib/coffee-script/nodes.js:46:21)
```

It appears that the CoffeeScript compiling application.coffee is quite
old (1.3.3). Still, unsure why this error wasn't happening locally but
also not eager to dig into it at the moment.
