### PR TITLE
Minor updates to the Node and CoffeeScript docs

### DIFF
--- a/app/pages/languages/getting-started-with-coffeescript.md
+++ b/app/pages/languages/getting-started-with-coffeescript.md
@@ -17,13 +17,13 @@ Install `jasmine-node` and `coffee`:
 $ npm install jasmine-node coffee -g
 ```
 
-Depending on your setup, you may need super user privileges to install an NPM module globally. This is the case if you've used the official installer linked to above. If NPM gives you an error saying you don't have access, add `sudo` to the command above:
+Depending on your setup, you may need super user privileges to install an `npm` module globally. This is the case if you've used the official installer linked to above. If NPM gives you an error saying you don't have access, add `sudo` to the command above:
 
 ```bash
 $ sudo npm install jasmine-node coffee -g
 ````
 
-Update your `PATH` to include the npm binaries by adding the following to either `~/.bash_profile` or `~/.zshrc`:
+If you've used the official installer, your `PATH` should have been automatically configured, but if your shell has trouble locating your globally installed modules—or if you build Node.js from source—update your `PATH` to include the `npm` binaries by adding the following to either `~/.bash_profile` or `~/.zshrc`:
 
 ```bash
 $ export PATH=/usr/local/share/npm/bin:$PATH
@@ -47,7 +47,7 @@ class Bob
 module.exports = Bob
 ```
 
-You can find more information about modules in the [node documentation](http://nodejs.org/api/modules.html#modules_module_exports).
+You can find more information about modules in the [Node documentation](http://nodejs.org/api/modules.html#modules_module_exports).
 
 ## Recommended Learning Resources
 

--- a/app/pages/languages/getting-started-with-coffeescript.md
+++ b/app/pages/languages/getting-started-with-coffeescript.md
@@ -5,7 +5,11 @@ category: "languages"
 ordinal: 2
 ---
 
-Make sure you have [Node.js installed](http://nodejs.org/) [via package manager](https://github.com/joyent/node/wiki/Installing-Node.js-via-package-manager)
+**Windows and OS X users**: Install [Node.js](http://nodejs.org/) [via package manager](https://github.com/joyent/node/wiki/Installing-Node.js-via-package-manager).
+
+**Linux users**: [Joyent maintains a document][linstall] that details how to get Node.js installed for a wide range of distributions and package managers.
+
+[linstall]: https://github.com/joyent/node/wiki/Installing-Node.js-via-package-manager
 
 Install `jasmine-node` and `coffee`:
 

--- a/app/pages/languages/getting-started-with-coffeescript.md
+++ b/app/pages/languages/getting-started-with-coffeescript.md
@@ -7,12 +7,17 @@ ordinal: 2
 
 Make sure you have [Node.js installed](http://nodejs.org/) [via package manager](https://github.com/joyent/node/wiki/Installing-Node.js-via-package-manager)
 
-Install jasmine-node and coffee:
+Install `jasmine-node` and `coffee`:
 
 ```bash
 $ npm install jasmine-node coffee -g
 ```
 
+Depending on your setup, you may need super user privileges to install an NPM module globally. This is the case if you've used the official installer linked to above. If NPM gives you an error saying you don't have access, add `sudo` to the command above:
+
+```bash
+$ sudo npm install jasmine-node coffee -g
+````
 
 Update your `PATH` to include the npm binaries by adding the following to either `~/.bash_profile` or `~/.zshrc`:
 

--- a/app/pages/languages/getting-started-with-javascript.md
+++ b/app/pages/languages/getting-started-with-javascript.md
@@ -23,7 +23,7 @@ Depending on your setup, you may need super user privileges to install an NPM mo
 $ sudo npm install jasmine-node -g
 ````
 
-Update your `PATH` to include the npm binaries by adding the following to either `~/.bash_profile` or `~/.zshrc`:
+If you've used the official installer, your `PATH` should have been automatically configured, but if your shell has trouble locating your globally installed modules—or if you build Node.js from source—update your `PATH` to include the `npm` binaries by adding the following to either `~/.bash_profile` or `~/.zshrc`:
 
 ```bash
 $ export PATH=/usr/local/share/npm/bin:$PATH

--- a/app/pages/languages/getting-started-with-javascript.md
+++ b/app/pages/languages/getting-started-with-javascript.md
@@ -7,11 +7,17 @@ ordinal: 7
 
 Install [Node.js](http://nodejs.org/) [via package manager](https://github.com/joyent/node/wiki/Installing-Node.js-via-package-manager)
 
-Install jasmine-node:
+Install `jasmine-node`:
 
 ```bash
 $ npm install jasmine-node -g
 ```
+
+Depending on your setup, you may need super user privileges to install an NPM module globally. This is the case if you've used the official installer linked to above. If NPM gives you an error saying you don't have access, add `sudo` to the command above:
+
+```bash
+$ sudo npm install jasmine-node -g
+````
 
 Update your `PATH` to include the npm binaries by adding the following to either `~/.bash_profile` or `~/.zshrc`:
 

--- a/app/pages/languages/getting-started-with-javascript.md
+++ b/app/pages/languages/getting-started-with-javascript.md
@@ -5,7 +5,11 @@ category: "languages"
 ordinal: 7
 ---
 
-Install [Node.js](http://nodejs.org/) [via package manager](https://github.com/joyent/node/wiki/Installing-Node.js-via-package-manager)
+**Windows and OS X users**: Install [Node.js](http://nodejs.org/) [via package manager](https://github.com/joyent/node/wiki/Installing-Node.js-via-package-manager).
+
+**Linux users**: [Joyent maintains a document][linstall] that details how to get Node.js installed for a wide range of distributions and package managers.
+
+[linstall]: https://github.com/joyent/node/wiki/Installing-Node.js-via-package-manager
 
 Install `jasmine-node`:
 


### PR DESCRIPTION
If you use just do `npm install -g jasmine-node`, most setups these days will bark at you and tell you don't have permissions. So, I added some instructions to guide the user if that happens.

I added some information for any Linux users who don't already know how to install Node.js (it turns out there is a `node` package in most package managers that has something to do with amateur radio or something). These days, the official installer updates your `PATH`, so the user _theoretically_ shouldn't have to worry about it.
