### PR TITLE
Elixir Docs: Add line to compile the source exs file

### DIFF
--- a/app/pages/languages/getting-started-with-elixir.md
+++ b/app/pages/languages/getting-started-with-elixir.md
@@ -32,6 +32,7 @@ Get [Erlang R16B](http://www.erlang.org/download.html), then [download a precomp
 ## Running tests
 
 ```bash
+$ elixirc bob.exs
 $ elixir bob_test.exs
 ```
 


### PR DESCRIPTION
We must compile the elixir source before we're able to execute the tests.

``` text
~/code/exercism/elixir/bob$ elixir bob_test.exs
** (FunctionClauseError) no function clause matching in ExUnit.DocTest.extract_from_moduledoc/1
    (ex_unit) lib/ex_unit/doc_test.ex:351: ExUnit.DocTest.extract_from_moduledoc(nil)
    (ex_unit) lib/ex_unit/doc_test.ex:342: ExUnit.DocTest.extract/1
    (ex_unit) lib/ex_unit/doc_test.ex:167: ExUnit.DocTest.__doctests__/2
    bob_test.exs:6: (module)

~/code/exercism/elixir/bob$ elixirc bob.exs
~/code/exercism/elixir/bob$ elixir bob_test.exs
# it works!
```

Thanks for this great language-learning tool!
