### PR TITLE
Match example directory with the first exercise

### DIFF
--- a/app/pages/languages/getting-started-with-go.md
+++ b/app/pages/languages/getting-started-with-go.md
@@ -14,7 +14,7 @@ Exercism supports Go 1.2 and higher.
 Go exercises within your exercism project directory can be run by changing to the exercise directory, and running `go test`.
 
 ```bash
-$ cd exercism/project/directory/go/bob
+$ cd exercism/project/directory/go/leap
 $ go test
 ```
 


### PR DESCRIPTION
At some point, the first exercise for exercism/xgo changed from "bob" to
"leap".
