### PR TITLE
Tweak lineman install instructions in the readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Borrowed heavily from [lineman-docs](https://github.com/linemanjs/lineman-docs).
 ## Getting Started
 
 1. Clone this repository.
-2. [Install lineman.js](https://github.com/linemanjs/lineman#install) if you haven't already.
+2. Run `npm install -g lineman` if you haven't already installed [lineman.js](https://github.com/linemanjs/lineman#install).
 3. Run `npm install` to install required project dependencies.
 4. Run `lineman run` while you work on writing markdown files. Visit the site on [localhost:8000](http://localhost:8000)
 


### PR DESCRIPTION
Wording the installation instructions the way I've proposed is a bit more explicit as most people are scanning for the relevant code blocks during the installation process.
