### PR TITLE
Remove $ from CLI docs

### DIFF
--- a/app/pages/process/fetching-exercises.md
+++ b/app/pages/process/fetching-exercises.md
@@ -8,7 +8,7 @@ ordinal: 10
 First configure the command-line client:
 
 ```bash
-$ exercism configure --key=YOUR_API_KEY
+exercism configure --key=YOUR_API_KEY
 ```
 
 Your API key can be found in your account settings.
@@ -23,13 +23,13 @@ using an environment variable named `EXERCISM_CONFIG_FILE`.
 To fetch your current exercises, issue the command:
 
 ```bash
-$ exercism fetch [language]
+exercism fetch [language]
 ```
 
 Or you can fetch all languages:
 
 ```bash
-$ exercism fetch
+exercism fetch
 ```
 
 The program will download the exercises to the configured project directory.
@@ -39,7 +39,7 @@ Note that the code will be put in that directory even if you are somewhere else 
 To start working on an exercise, go find the downloaded files.
 
 ```bash
-$ cd path/to/exercism/project # or whatever
+cd path/to/exercism/project # or whatever
 ```
 
 You can work on them using your usual editor, tools, and environment. Read the <a class="link-side-menu" href="#sidr">getting started guide</a> of your language to find out how to run the tests.

--- a/app/pages/process/installing-the-cli-on-linux.md
+++ b/app/pages/process/installing-the-cli-on-linux.md
@@ -25,8 +25,8 @@ chmod +x install
 ```
 
 ```bash
-$ wget http://cli.exercism.io/install
-$ chmod +x install
+wget http://cli.exercism.io/install
+chmod +x install
 ```
 
 Read it before you run it, people.

--- a/app/pages/process/installing-the-cli-on-mac.md
+++ b/app/pages/process/installing-the-cli-on-mac.md
@@ -110,8 +110,8 @@ exercism
 You'll need to get access to the homebrew/binary repository, then use `brew install` as usual:
 
 ```bash
-$ brew tap homebrew/binary
-$ brew install exercism
+brew tap homebrew/binary
+brew install exercism
 ```
 
 The homebrew version of exercism will often lag a bit behind for a few days after a new release has been made, since it requires a pull request to be accepted into the homebrew-binary project before it's available.

--- a/app/pages/process/submitting-exercises.md
+++ b/app/pages/process/submitting-exercises.md
@@ -8,14 +8,18 @@ ordinal: 21
 After you've [fetched the exercises](/help/fetch) and written an implementation that gets the tests passing, then you're ready to submit the code to the website so you can discuss its merits and receive feedback.
 
 ```bash
-$ exercism submit path/to/your/code.ext
+exercism submit path/to/your/code.ext
 ```
 
 For example, if you have been working on the `leap` exercise in Go, you might be in the same directory as the test suite and the code:
 
 ```bash
-$ cd ~/exercism/go/leap
-$ ls -1
+cd ~/exercism/go/leap
+ls -1
+```
+
+This would output the following:
+```
 leap.go
 leap_test.go
 README.md
@@ -24,7 +28,7 @@ README.md
 Then you would submit the code with the following command:
 
 ```bash
-$ exercism submit leap.go
+exercism submit leap.go
 ```
 
 If you get a better idea of how to express your code, perhaps coming from


### PR DESCRIPTION
This closes [issue 1981](https://github.com/exercism/exercism.io/issues/1981) in  the `exercism.io` repo.
