### PR TITLE
Use uninterned symbols for package definition

### DIFF
--- a/app/pages/languages/getting-started-with-lisp.md
+++ b/app/pages/languages/getting-started-with-lisp.md
@@ -51,10 +51,10 @@ for the first exercise, put this code in `bob.lisp`:
 
 ```lisp
 (cl:defpackage #:bob
-  (:use :common-lisp)
-  (:export :response-for))
+  (:use #:common-lisp)
+  (:export #:response-for))
 
-(in-package :bob)
+(in-package #:bob)
 
 (defun response-for (msg) "Whatever.")
 ```


### PR DESCRIPTION
This is the "modern style". See examples and rationale here: http://www.cs.northwestern.edu/academics/courses/325/readings/packages.php
