### PR TITLE
Fix sidebar flashing open on page load

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@
 
 .sass-cache
 /.project
+
+npm-debug.log

--- a/app/css/_sidebar.scss
+++ b/app/css/_sidebar.scss
@@ -16,6 +16,7 @@
     padding-left: 15px;
     list-style-type: none;
   }
+  display: none;
 }
 
 #simple-menu, .close {


### PR DESCRIPTION
As per https://github.com/artberri/sidr/issues/60

Closes exercism/exercism.io#2188

Before, the sidebar would be open for a fraction of a second on page
load. Clicking on the big logo caused the page to reload, triggering
the sidebar to open for that fraction of a second.

This change makes it so that the sidebar no longer flashes open on page
load.
