### PR TITLE
Add pro-git book link in git-workflow resources.

### DIFF
--- a/app/pages/contributing/git-workflow.md
+++ b/app/pages/contributing/git-workflow.md
@@ -165,6 +165,7 @@ If you're completely new to git, there are a number of resources that can help g
 
 If you've been using git for a while, but it feels like repeating magical incantations (while praying that nothing goes wrong), then you may find these helpful:
 
+* [Pro Git](http://git-scm.com/book/en/v2) - "The Book" for learning Git in detail
 * [Explain Git with D3](http://www.wei-wang.com/ExplainGitWithD3) - interactive site
 * [Git Branching Tutorial](http://pcottle.github.io/learnGitBranching/) - interactive tutorial, very visual
 * [Git for Ages 4 and Up](https://www.youtube.com/watch?v=1ffBJ4sVUb4) - video of a presentation/demo


### PR DESCRIPTION
As discussed in the gitter channel, I have added the link to pro-git book in the advanced resources section of git-workflow.
