### PR TITLE
Make stackoverflow link to be pointed to ruby tagged questions.

### DIFF
--- a/app/pages/languages/getting-started-with-ruby.md
+++ b/app/pages/languages/getting-started-with-ruby.md
@@ -35,4 +35,4 @@ Exercism provides exercises and feedback but can be difficult to jump into for t
 * [RubyLearning.com](http://www.rubylearning.com/) - Ruby Tutorial and Study Notes
 * [RubyLearning.org](http://rubylearning.org/classes/) - Professionally Taught and Moderated Classes
 * [Learn to Program](http://pine.fm/LearnToProgram/) - A book (available online) written by Chris Pine
-* [StackOverflow](http://stackoverflow.com/)
+* [StackOverflow](http://stackoverflow.com/questions/tagged/ruby)


### PR DESCRIPTION
Instead of pointing to just stackoverflow.com.
