### PR TITLE
Fix #143 - Gradle task for IntelliJ setup

### DIFF
--- a/app/pages/languages/getting-started-with-java.md
+++ b/app/pages/languages/getting-started-with-java.md
@@ -63,9 +63,9 @@ For Eclipse,
 
 generates the `.project` file and `.settings/` directory. In Eclipse, import this project into your workspace: File > Import > Existing Projects Into Workspace.
 
-For IntelliJ,
+For IntelliJ IDEA,
 
-    gradle intellij
+    gradle idea
 
 generates the `<project-name>.iml` file and `.idea/` directory. In IntelliJ, open this project: File > Open.
 


### PR DESCRIPTION
Fixes Gradle task documentation for generating IntelliJ IDEA files.

I think there's still more to be done for IDE import w/ exercism and gradle, b/c there are still gotchas, but I tested importing the bob exercise with `gradle idea` and all is well.
