### PR TITLE
rephrase creating empty files in shell

### DIFF
--- a/app/pages/languages/getting-started-with-cpp.md
+++ b/app/pages/languages/getting-started-with-cpp.md
@@ -304,8 +304,7 @@ The generator name for CMake is `Unix Makefiles`.
 Assuming the current exercise is `bob` and we're in the exercise folder:
 
 ```
-$ cp /dev/null bob.h
-$ cp /dev/null bob.cpp
+$ touch bob.{h,cpp}
 $ mkdir build
 $ cd build
 $ cmake -G "Unix Makefiles" ..
@@ -355,8 +354,7 @@ The generator name for CMake is `Xcode`.
 Assuming the current exercise is `bob` and we're in the exercise folder:
 
 ```
-$ cp /dev/null bob.h
-$ cp /dev/null bob.cpp
+$ touch bob.{h,cpp}
 $ mkdir build
 $ cd build
 $ cmake -G Xcode ..
@@ -371,8 +369,7 @@ The generator name for CMake is `Unix Makefiles`.
 Assuming the current exercise is `bob` and we're in the exercise folder:
 
 ```
-$ cp /dev/null bob.h
-$ cp /dev/null bob.cpp
+$ touch bob.{h,cpp}
 $ mkdir build
 $ cd build
 $ cmake -G "Unix Makefiles" ..


### PR DESCRIPTION
I find it simpler and more expressive to create a new empty file with the `touch` utility rather than `cp`. Also, I find dealing with a pair of header and implementation files a classic use case for the shell's curly braces. It's pretty and it saves a line.
