### PR TITLE
Add next doc links on all pages.

### DIFF
--- a/app/pages/process/configuring-the-cli.md
+++ b/app/pages/process/configuring-the-cli.md
@@ -32,3 +32,6 @@ flags, see `exercism help configure` for more details.
 The configuration is written to `~/.exercism.json`. This can be configured
 using an environment variable named `EXERCISM_CONFIG_FILE`.
 You can also edit this file instead of running `exercism configure` command.
+
+
+<a class="secondary-button" href="fetching-exercises.html">Fetching Exercises</a>

--- a/app/pages/process/nitpicking-code.md
+++ b/app/pages/process/nitpicking-code.md
@@ -26,3 +26,6 @@ Please note that _good job_ or _great work_ are not positive, constructive feedb
 When leaving nitpicks, please remember that beginners do not always have the same confidence level as more experienced developers. It is therefore important to be courteous and considerate. Strive to be clear in your explanations and give users a chance to arrive at their own improvements. Might the Socratic Method be a suitable approach?
 
 > A rising tide lifts all the boats. - Unknown
+
+
+<a class="secondary-button" href="hibernation.html">Hibernation</a>


### PR DESCRIPTION
Next page navigation links were missing on these two pages: `configuring-the-cli` and `nitpicking`
