### PR TITLE
Revised steps for creating a project in Xcode 7

### DIFF
--- a/app/pages/languages/getting-started-with-objective-c.md
+++ b/app/pages/languages/getting-started-with-objective-c.md
@@ -11,26 +11,33 @@ Ensure that you have the latest Xcode installed through the Mac App Store.
 
 ## Running Tests
 
-Exercism will only download a test file. You will need to manually create the header and the source file associated with the exercise. You will need to generate an Xcode Project file with the test file, the header file (.h) and the source file (.m).
+Exercism will only download a test file. You will need to manually create the header and the source file associated with the exercise. You will need to generate an Xcode Project file with the test file, the header file (.h) and the source file (.m). Alternatively, you can use a test runner utility that's described below.
 
 ### Creating the project in Xcode
 
-* Start Xcode create a new project.
-* Select OSX-->Application and then Command Line Tool.
+* Start Xcode and create a new project.
+* Select OS X > Application and then Command Line Tool.
 * Click Next and give it a project name using the ExerciseName is advised.
-* Click Next until the wizard is finished.
-* Now that the project is created click on Editor-->Add Target.
-* Select OSX-->Other and select Cocoa Testing Bundle.
+* Click Next and save the project in exercism's exercise directory.
+* Now that the project is created click on Editor > Add Target.
+* Select OS X > Test and select OS X Unit Testing Bundle.
 * Name the target ExerciseName Tests.
-* Open the new file which will be named ExerciseName_Tests.m in a folder called ExerciseName Tests and replace the contents with the test file you got from exercism.
-* Create a new OS X Cocoa Class with the correct name for the exercise.
-* Click on your project in the left hand pane.
-* Select Build Phases on the right.
-* Add your .m files to the compile sources list.
-* Use CMD-5 to navigate to the test navigator.
-* Run the tests by clicking on the right pointing arrow that appear when hovering over the bundle named ExerciseName Tests in the test navigator.
+* In the left pane (known as the navigator), open the Project navigator and expand the folder ExerciseName Tests and open the file ExerciseName_Tests.m.
+* Replace its contents with the test file you got from exercism.
+* In that file, replace all instances of "test_suite" with "ExerciseName_Tests."
+* Navigate to the File Template library in the right pane (or use CTRL+OPTION+CMD+1) and drag the Cocoa Class template into the ExerciseName_Tests folder in the Project navigator.
+* Name it ExerciseName and select ExerciseName Tests as its target.
+* You will now have two new files in your ExerciseName_Tests directory: ExerciseName.h and ExerciseName.m.
+* Click on your project in the Project navigator.
+* Select Build Phases in the editor's navigation.
+* Confirm that both your .m files are in the compile sources list.
+* Use CMD+5 to navigate to the Test navigator.
+* Right click the bundle named ExerciseName Tests and click Enable ExerciseName_Tests.
+* Run the tests by clicking on the right pointing triangle that appears when hovering over the bundle in the Test navigator or use CMD+U.
 
 Tests will be run through Xcode.
+
+__Note:__ If you receive the error "No visible `@interface` for ExerciseName declares the selector ExerciseSelector," you followed the steps correctly, but haven't written anything in your header/implementation file(s). After you declare your method in the .h file and define it in the .m file, your tests should raise more helpful errors that will lead you towards completing the exercise. Read this [primer on Objective-C Classes](http://blog.teamtreehouse.com/beginners-guide-objective-c-classes-objects) for more in-depth information.
 
 ### A Test Runner
 


### PR DESCRIPTION
The instructions on running tests for Xcode are out of date for Xcode 7. 

I wrote the note for those of us who are total n00bs to Xcode & Objective-C. Initially, I wasn't sure if the `@import` error was part of the exercise or something I had done wrong in setting up Xcode. That paragraph will hopefully be enough to clear it up for anyone else who might be confused. 
