### PR TITLE
Fix image link in F# docs for Xamarin NUnit setup

### DIFF
--- a/app/pages/languages/getting-started-with-fsharp.md
+++ b/app/pages/languages/getting-started-with-fsharp.md
@@ -93,7 +93,7 @@ Now you can have fun learning F# and run your code against the tests!
 ### Mac
 Xamarin Studio also ships with NUnit. From the new project dialog, just select an NUnit class library.
 
-![Xamarin NUnit](/img/setup/fsharp/xamarin-fsharp-nunit.jpeg)
+![Xamarin NUnit](/img/setup/fsharp/xamarin-fsharp-nunit.jpg)
 
 From here you can write NUnit tests right away. To run the tests open the `Unit Tests` pad within
 Xamarin (View -> Pads -> Unit Tests).


### PR DESCRIPTION
The exercism.io F# "Running Tests" documentation (http://exercism.io/languages/fsharp) has the following broken link:

http://x.exercism.io/v3/tracks/fsharp/docs/img/xamarin-fsharp-nunit.jpeg

It appears that the intended image file is saved with a .jpg extension:

https://github.com/exercism/docs/blob/master/app/img/setup/fsharp/xamarin-fsharp-nunit.jpg

This pull request aims to change the broken image link to the following address:

http://x.exercism.io/v3/tracks/fsharp/docs/img/xamarin-fsharp-nunit.jpg
