### PR TITLE
Removes out-of-date warning for AUR package

### DIFF
--- a/app/pages/process/installing-the-cli-on-linux.md
+++ b/app/pages/process/installing-the-cli-on-linux.md
@@ -78,6 +78,6 @@ DIR=/path/to/bin ./install
 
 These are not officially supported, and sometimes (often) lag behind the latest release.
 
-There's a [freshports build](http://www.freshports.org/misc/exercism), and an [AUR package](https://aur.archlinux.org/packages/exercism-cli). The AUR package appears to be wildly out of date.
+There's a [freshports build](http://www.freshports.org/misc/exercism), and an [AUR package](https://aur.archlinux.org/packages/exercism-cli).
 
 <a class="secondary-button" href="fetching-exercises.html">Fetching Exercises</a>


### PR DESCRIPTION
AUR package is up-to-date and works. Should be OK to remove this comment now :smile_cat:
